### PR TITLE
docs: update context and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # sentry-fullstory
-The Sentry-FullStory integration creates a link from the Sentry error to the FullStory replay. It also creates a link from the FullStory event to the Sentry error.
+
+The Sentry-FullStory integration seamlessly integrates the Sentry and FullStory platforms. When you look at a browser error in Sentry, you will see a link to the FullStory session replay at that exact moment in time. When you are watching a FullStory replay and your user experiences an error, you will see a link that will take you to that error in Sentry.
 
 ## Pre-Requisites
 
-For the Sentry-FullStory integration to work, you must have the [Sentry browser SDK package](https://www.npmjs.com/package/@sentry/browser) and FullStory running.
+For the Sentry-FullStory integration to work, you must have the [Sentry browser SDK package](https://www.npmjs.com/package/@sentry/browser) and the [FullStory browser SDK package](https://www.npmjs.com/package/@fullstorydev/browser).
 
 ## Installation
 To install the stable version:
@@ -20,6 +21,8 @@ yarn add sentry-fullstory
 
 
 ## Setup
+
+### Code Changes
 
 To set up the integration, both FullStory and Sentry need to be initialized. Please add the following code:
 
@@ -42,3 +45,22 @@ Replace `__SENTRY_ORG_SLUG__` with the organization for your slug. You can get t
 
 
 You also need to replace `__FULLSTORY_ORG_ID__` with the value of `_fs_org` in the FullStory recording snippet on your [FullStory settings page](https://help.fullstory.com/hc/en-us/articles/360020623514).
+
+
+### Sentry Settings Change
+
+In order for this integration to work properly, you need to whitelist the `fullStoryUrl` field in your Sentry settings. If you don't, the FullStory URL might be scrubbed because the session matches a credit card regex. To do this change, go to `Settings` -> `General`, find the heading `SECURITY & PRIVACY`, and add `fullStoryUrl` to the `Global Safe Fields` entry.
+
+
+![Settings](https://i.imgur.com/Il1Epkh.png)
+
+## How it works
+
+In Sentry, you should see additional context of your error that has the `fullStoryUrl` below the breadcrumbs and other information:
+
+![Sentry](https://i.imgur.com/O4r4Wvq.png)
+
+
+In FullStory, you should see an event called `Sentry Error` on the right sidebar that has a link to the error in Sentry:
+
+![FullStory](https://i.imgur.com/FutjI0R.png)

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ You also need to replace `__FULLSTORY_ORG_ID__` with the value of `_fs_org` in t
 
 ### Sentry Settings Change
 
-In order for this integration to work properly, you need to whitelist the `fullStoryUrl` field in your Sentry settings. If you don't, the FullStory URL might be scrubbed because the session matches a credit card regex. To do this change, go to `Settings` -> `General`, find the heading `SECURITY & PRIVACY`, and add `fullStoryUrl` to the `Global Safe Fields` entry.
+In order for this integration to work properly, you need to whitelist the `fullStoryUrl` field in your Sentry settings. If you don't, the FullStory URL might be scrubbed because the session ID matches a credit card regex. To do this change, go to `Settings` -> `General`, find the heading `SECURITY & PRIVACY`, and add `fullStoryUrl` to the `Global Safe Fields` entry.
 
 
 ![Settings](https://i.imgur.com/Il1Epkh.png)

--- a/src/SentryFullStory.ts
+++ b/src/SentryFullStory.ts
@@ -35,7 +35,7 @@ class SentryFullStory {
         event.contexts = {
           ...event.contexts,
           fullStory: {
-            url:
+            fullStoryUrl:
               FullStory.getCurrentSessionURL(true) ||
               'current session URL API not ready'
           }


### PR DESCRIPTION
It seems that the FullStory session ID matches a regex used for data scrubbing. To get around this issue, you can add the field to a whitelist of safe fields. I decided it was better to change the field from `url` to `fullStoryUrl` so it's more unique. Here's an example of what it looks like when you don't have the field on the whitelist:

![Scrubbing](https://user-images.githubusercontent.com/8533851/71287467-4cef5b00-231d-11ea-8464-80ce420e10c3.png)


Also updated docs, including screenshots of how it looks in Sentry and FullStory.