### PR TITLE
adding message and name fields to FS.event call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## 1.1.0
+
+Updating the call to `FS.event` to include the `message` and `name` properties of the original exception.
+
+## 1.0.0
+
+Initial Release

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentry/fullstory",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "The Sentry-FullStory integration creates a link from the Sentry Error to the FullStory replay. It also creates a link from the FullStory event to the Sentry error.",
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/src/SentryFullStory.ts
+++ b/src/SentryFullStory.ts
@@ -41,6 +41,17 @@ class SentryFullStory {
           }
         };
 
+        let name = '';
+        let message = '';
+        const isError = (exception: string | Error): exception is Error => {
+          return (exception as Error).message !== undefined;
+        };
+        if (isError(hint.originalException)) {
+          const originalException = hint.originalException as Error;
+          name = originalException.name;
+          message = originalException.message;
+        }
+
         let sentryUrl: string;
         try {
           //No docs on this but the SDK team assures me it works unless you bind another Sentry client
@@ -56,7 +67,11 @@ class SentryFullStory {
         }
 
         // FS.event is immediately ready even if FullStory isn't fully bootstrapped
-        FullStory.event('Sentry Error', { sentryUrl });
+        FullStory.event('Sentry Error', {
+          sentryUrl,
+          name,
+          message
+        });
       }
       return event;
     });

--- a/src/SentryFullStory.ts
+++ b/src/SentryFullStory.ts
@@ -41,17 +41,6 @@ class SentryFullStory {
           }
         };
 
-        let name = '';
-        let message = '';
-        const isError = (exception: string | Error): exception is Error => {
-          return (exception as Error).message !== undefined;
-        };
-        if (isError(hint.originalException)) {
-          const originalException = hint.originalException as Error;
-          name = originalException.name;
-          message = originalException.message;
-        }
-
         let sentryUrl: string;
         try {
           //No docs on this but the SDK team assures me it works unless you bind another Sentry client
@@ -69,8 +58,7 @@ class SentryFullStory {
         // FS.event is immediately ready even if FullStory isn't fully bootstrapped
         FullStory.event('Sentry Error', {
           sentryUrl,
-          name,
-          message
+          ...util.getOriginalExceptionProperties(hint)
         });
       }
       return event;

--- a/src/util.ts
+++ b/src/util.ts
@@ -36,13 +36,11 @@ const isError = (exception: string | Error): exception is Error => {
  * @param {EventHint} hint
  */
 export const getOriginalExceptionProperties = (hint: EventHint) => {
-  let name = '';
-  let message = '';
   if (isError(hint.originalException)) {
     const originalException = hint.originalException as Error;
-    name = originalException.name;
-    message = originalException.message;
+    const { name, message } = originalException;
+    return { name, message };
   }
 
-  return { name, message };
+  return {};
 };

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,3 +1,5 @@
+import { EventHint } from '@sentry/types';
+
 /**
  * Split the URL into different parts
  * taken from https://stackoverflow.com/questions/736513/how-do-i-parse-a-url-into-hostname-and-path-in-javascript
@@ -23,4 +25,24 @@ const splitUrlIntoParts = (url: string) => {
 export const getProjectIdFromSentryDsn = (dsn: string) => {
   const search = splitUrlIntoParts(dsn)[5];
   return search.replace('/', '');
+};
+
+const isError = (exception: string | Error): exception is Error => {
+  return (exception as Error).message !== undefined;
+};
+
+/**
+ * Get the message and name properties from the original exception
+ * @param {EventHint} hint
+ */
+export const getOriginalExceptionProperties = (hint: EventHint) => {
+  let name = '';
+  let message = '';
+  if (isError(hint.originalException)) {
+    const originalException = hint.originalException as Error;
+    name = originalException.name;
+    message = originalException.message;
+  }
+
+  return { name, message };
 };


### PR DESCRIPTION
I'm updating the `FS.event` invocation to pass in the `message` and `name` properties of the original exception.