### PR TITLE
Update FullStory reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.1.1
+
+Updating `@fullstorydev/browser` dependancies to `@fullstory/browser`
+
 ## 1.1.0
 
 Updating the call to `FS.event` to include the `message` and `name` properties of the original exception.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The Sentry-FullStory integration seamlessly integrates the Sentry and FullStory 
 
 ## Pre-Requisites
 
-For the Sentry-FullStory integration to work, you must have the [Sentry browser SDK package](https://www.npmjs.com/package/@sentry/browser) and the [FullStory browser SDK package](https://www.npmjs.com/package/@fullstorydev/browser).
+For the Sentry-FullStory integration to work, you must have the [Sentry browser SDK package](https://www.npmjs.com/package/@sentry/browser) and the [FullStory browser SDK package](https://www.npmjs.com/package/@fullstory/browser).
 
 ## Installation
 To install the stable version:
@@ -29,8 +29,8 @@ To set up the integration, both FullStory and Sentry need to be initialized. Ple
 
 ```
 import * as Sentry from '@sentry/browser';
-import * as FullStory from '@fullstorydev/browser';
-import SentryFullStory from '@sentry/sentry-fullstory';
+import * as FullStory from '@fullstory/browser';
+import SentryFullStory from '@sentry/sentry';
 
 FullStory.init({ orgId = '__FULLSTORY_ORG_ID__' });
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {},
   "devDependencies": {
     "@babel/core": "^7.7.2",
-    "@fullstory/browser": "^1.0.0",
+    "@fullstory/browser": "^1.0.1",
     "@sentry/browser": "^5.10.2",
     "@sentry/types": "^5.10.0",
     "rimraf": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -23,13 +23,13 @@
   },
   "homepage": "https://github.com/getsentry/sentry-fullstory#readme",
   "peerDependencies": {
-    "@fullstorydev/browser": ">=2.0.0",
+    "@fullstory/browser": ">=1.0.0",
     "@sentry/browser": ">=4.0.0"
   },
   "dependencies": {},
   "devDependencies": {
     "@babel/core": "^7.7.2",
-    "@fullstorydev/browser": "^2.0.0",
+    "@fullstory/browser": "^1.0.0",
     "@sentry/browser": "^5.10.2",
     "@sentry/types": "^5.10.0",
     "rimraf": "^3.0.0",

--- a/src/SentryFullStory.ts
+++ b/src/SentryFullStory.ts
@@ -1,6 +1,6 @@
 import * as Sentry from '@sentry/browser';
 import { Event, EventHint } from '@sentry/types';
-import * as FullStory from '@fullstorydev/browser';
+import * as FullStory from '@fullstory/browser';
 
 import * as util from './util';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -134,10 +134,10 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
-"@fullstorydev/browser@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@fullstorydev/browser/-/browser-2.0.0.tgz#39858958c34bfa46eaf5d33a915a300c4889d2d2"
-  integrity sha512-qempD7zrZBviGjk7MBJTBrgz3taLp97CIlueiT34AOSYuPzp1SL14eUEoJ3YAOAyydNyW7f4axdQFbGmMmPCCA==
+"@fullstory/browser@^1.0.0":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@fullstory/browser/-/browser-1.0.1.tgz#a513c13fe5f689f00bbd98bbcdb3d470da58e2e2"
+  integrity sha512-23PhplNWI77AxLYANKOMjDYOylaK4NnmlND498upH1xgYUDoH7E7SZVaXYwVCoeCAS2tFEstkyy4aLDue7EOTg==
 
 "@sentry/browser@^5.10.2":
   version "5.10.2"


### PR DESCRIPTION
Hello! We've recently acquired the `@fullstory` NPM org and thus have updated our package to `@fullstory/browser` from `@fullstorydev/browser`

This PR updates package.json, yarn.lock, and the `import` statement to point to the new org.