### PR TITLE
Fixes typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ import * as Sentry from '@sentry/browser';
 import * as FullStory from '@fullstorydev/browser';
 import SentryFullStory from '@sentry/sentry-fullstory';
 
-FullStory.init({ orgId = '__FULLSTORY_ORG_ID__' });
+FullStory.init({ orgId: '__FULLSTORY_ORG_ID__' });
 
 Sentry.init({
   dsn: '__DSN__',

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ To set up the integration, both FullStory and Sentry need to be initialized. Ple
 ```
 import * as Sentry from '@sentry/browser';
 import * as FullStory from '@fullstory/browser';
-import SentryFullStory from '@sentry/sentry';
+import SentryFullStory from '@sentry/fullstory';
 
 FullStory.init({ orgId: '__FULLSTORY_ORG_ID__' });
 


### PR DESCRIPTION
Fixes: https://github.com/getsentry/sentry-fullstory/issues/22

Also fixes the incorrect importation of this integration:
```
import SentryFullStory from '@sentry/fullstory';
```