### PR TITLE
build: add tsconfig.json file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.1.1
 
 Updating `@fullstorydev/browser` dependancies to `@fullstory/browser`
+Adds Typescript output files to dist
 
 ## 1.1.0
 

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "The Sentry-FullStory integration creates a link from the Sentry Error to the FullStory replay. It also creates a link from the FullStory event to the Sentry error.",
   "main": "dist/index.js",
   "module": "dist/index.es.js",
+  "types": "dist/index.d.ts",
   "scripts": {
     "clean": "rimraf dist",
     "build": "yarn clean && rollup -c",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "declaration": true,
+    "declarationDir": "./dist",
+    "module": "es6",
+    "noImplicitAny": true,
+    "outDir": "./dist",
+    "target": "es5"
+  },
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": ["node_modules"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -134,7 +134,7 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
-"@fullstory/browser@^1.0.0":
+"@fullstory/browser@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@fullstory/browser/-/browser-1.0.1.tgz#a513c13fe5f689f00bbd98bbcdb3d470da58e2e2"
   integrity sha512-23PhplNWI77AxLYANKOMjDYOylaK4NnmlND498upH1xgYUDoH7E7SZVaXYwVCoeCAS2tFEstkyy4aLDue7EOTg==


### PR DESCRIPTION
This PR adds a tsconfig.json file which will generate Typescript output files. Solves https://github.com/getsentry/sentry-fullstory/issues/16