### PR TITLE
Make hint and hint.originalException optional Fixes #34

### DIFF
--- a/src/SentryFullStory.ts
+++ b/src/SentryFullStory.ts
@@ -25,7 +25,7 @@ class SentryFullStory {
     this.baseSentryUrl = options.baseSentryUrl || 'https://sentry.io';
   }
   setupOnce() {
-    Sentry.addGlobalEventProcessor((event: Event, hint: EventHint) => {
+    Sentry.addGlobalEventProcessor((event: Event, hint?: EventHint) => {
       const self = Sentry.getCurrentHub().getIntegration(SentryFullStory);
       // Run the integration ONLY when it was installed on the current Hub
       if (self) {
@@ -37,16 +37,14 @@ class SentryFullStory {
           fullStory: {
             fullStoryUrl:
               FullStory.getCurrentSessionURL(true) ||
-              'current session URL API not ready'
-          }
+              'current session URL API not ready',
+          },
         };
 
         let sentryUrl: string;
         try {
           //No docs on this but the SDK team assures me it works unless you bind another Sentry client
-          const { dsn } = Sentry.getCurrentHub()
-            .getClient()
-            .getOptions();
+          const { dsn } = Sentry.getCurrentHub().getClient().getOptions();
           const projectId = util.getProjectIdFromSentryDsn(dsn);
           sentryUrl = `${this.baseSentryUrl}/organizations/${this.sentryOrg}/issues/?project=${projectId}&query=${hint.event_id}`;
         } catch (_err) {
@@ -58,7 +56,7 @@ class SentryFullStory {
         // FS.event is immediately ready even if FullStory isn't fully bootstrapped
         FullStory.event('Sentry Error', {
           sentryUrl,
-          ...util.getOriginalExceptionProperties(hint)
+          ...util.getOriginalExceptionProperties(hint),
         });
       }
       return event;

--- a/src/util.ts
+++ b/src/util.ts
@@ -12,7 +12,7 @@ const splitUrlIntoParts = (url: string) => {
       '(([^:/?#]*)(?::([0-9]+))?)', // host (hostname and port)
       '(/{0,1}[^?#]*)', // pathname
       '(\\?[^#]*|)', // search
-      '(#.*|)$' // hash
+      '(#.*|)$', // hash
     ].join('')
   );
   return url.match(reURLInformation);
@@ -35,8 +35,8 @@ const isError = (exception: string | Error): exception is Error => {
  * Get the message and name properties from the original exception
  * @param {EventHint} hint
  */
-export const getOriginalExceptionProperties = (hint: EventHint) => {
-  if (isError(hint.originalException)) {
+export const getOriginalExceptionProperties = (hint?: EventHint) => {
+  if (hint && isError(hint.originalException)) {
     const originalException = hint.originalException as Error;
     const { name, message } = originalException;
     return { name, message };


### PR DESCRIPTION
By marking `hint` in the callback to `addGlobalEventProcessor` as optional, it reflects the `EventProcessor` type. This leads to updating `utils.getOriginalExceptionProperties` to have `hint` be optional there as well. Which led to just a small update in that file to check for that first.