### PR TITLE
fix(events): Prevent FS events on Sentry performance transactions

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,5 +38,9 @@
     "rollup-plugin-babel": "^4.3.3",
     "rollup-plugin-typescript2": "^0.25.3",
     "typescript": "^3.8"
+  },
+  "volta": {
+    "node": "12.19.0",
+    "yarn": "1.22.5"
   }
 }

--- a/src/SentryFullStory.ts
+++ b/src/SentryFullStory.ts
@@ -7,7 +7,7 @@ import * as util from './util';
 /**
  * This integration creates a link from the Sentry Error to the FullStory replay.
  * It also creates a link from the FullStory event to the Sentry error.
- * Docs on Sentry SDK integrations are here: https://docs.sentry.io/platforms/javascript/advance-settings/#dealing-with-integrations
+ * Docs on Sentry SDK integrations are here: https://docs.sentry.io/platforms/javascript/guides/angular/troubleshooting/#dealing-with-integrations
  */
 
 type Options = {
@@ -34,7 +34,7 @@ class SentryFullStory {
           const { dsn } =
             Sentry.getCurrentHub().getClient()?.getOptions() || {};
           if (!dsn) {
-            console.error('No sn');
+            console.error('No DSN');
             return 'Could not retrieve url';
           }
           if (!hint) {
@@ -51,8 +51,8 @@ class SentryFullStory {
       };
 
       const self = Sentry.getCurrentHub().getIntegration(SentryFullStory);
-      // Run the integration ONLY when it was installed on the current Hub
-      if (self) {
+      // Run the integration ONLY when it was installed on the current Hub AND isn't a transaction
+      if (self && event.type !== 'transaction') {
         // getCurrentSessionURL isn't available until after the FullStory script is fully bootstrapped.
         // If an error occurs before getCurrentSessionURL is ready, make a note in Sentry and move on.
         // More on getCurrentSessionURL here: https://help.fullstory.com/develop-js/getcurrentsessionurl


### PR DESCRIPTION
See [API-1799](https://getsentry.atlassian.net/browse/API-1799)

This PR will now make it so that we don't send FS Events for every sentry event, only those without the type "transaction".

**Before**:


<img width="361" alt="image" src="https://user-images.githubusercontent.com/35509934/139131305-1b437aeb-6fda-43a3-add9-8f1a12b9db8b.png">

**After**:
This video shows a demo app that makes transactions and errors. When the transaction is recorded (the API call to get a cat fact), there is no FS event. FS events only show up when I trigger the SDK to start recording errors.

https://user-images.githubusercontent.com/35509934/139131687-4666d88b-3289-49f6-b1c3-f566a899c25b.mov
