### PR TITLE
feat(ci): Use getsentry/publish to automate releases with gha

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -1,8 +1,9 @@
 ---
+changelogPolicy: simple
 github:
   owner: getsentry
   repo: sentry-fullstory
-changelogPolicy: simple
+minVersion: "0.24.4"
 preReleaseCommand: bash scripts/craft-pre-release.sh
 targets:
   - name: npm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,29 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Version to release
+        required: true
+      force:
+        description: Force a release even when there are release-blockers (optional)
+        required: false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    name: 'Release a new version'
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.GH_RELEASE_PAT }}
+          fetch-depth: 0
+
+      - name: Prepare release
+        uses: getsentry/action-prepare-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_RELEASE_PAT }}
+        with:
+          version: ${{ github.event.inputs.version }}
+          force: ${{ github.event.inputs.force }}

--- a/README.md
+++ b/README.md
@@ -71,8 +71,6 @@ In FullStory, you should see an event called `Sentry Error` on the right sidebar
 
 ## Development
 
-To setup this module locally, you'll need a few things:
-
 ### Before you start...
 
 To get up and running with this project, you'll need a few things:


### PR DESCRIPTION
Does what it says up there ^^.

Explicitly followed the docs in the README of https://github.com/getsentry/publish/