### PR TITLE
refactor(core): refactoring to achieve platform agnostic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 2.0.0
 
 Refactoring the whole integration so it's platform agnostic.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+Refactoring the whole integration so it's platform agnostic.
+
+**BREAKING CHANGES:** users now must provide the `FullStory` client as an option in the args.
+
 ## 1.1.8
 
 Allow a custom FullStory Client to be passed as an option (e.g. from Segment)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The Sentry-FullStory integration seamlessly integrates the Sentry and FullStory 
 
 ## Pre-Requisites
 
-For the Sentry-FullStory integration to work, you must have the [Sentry browser SDK package](https://www.npmjs.com/package/@sentry/browser) and the [FullStory browser SDK package](https://www.npmjs.com/package/@fullstory/browser).
+For the Sentry-FullStory integration to work, you must have the [Sentry Browser SDK package](https://www.npmjs.com/package/@sentry/browser) or the [Sentry React Native SDK package](https://www.npmjs.com/package/@sentry/react-native) and the [FullStory Browser SDK package](https://www.npmjs.com/package/@fullstory/browser) or the [FullStory React Native SDK package](https://www.npmjs.com/package/@fullstory/react-native) respectively.
 
 ### On-Premise Installations
 
@@ -30,20 +30,23 @@ yarn add @sentry/fullstory
 
 To set up the integration, both FullStory and Sentry need to be initialized. Please add the following code:
 
-
-```
+```javascript
 import * as Sentry from '@sentry/browser';
+// import * as Sentry from '@sentry/react-native';
 import * as FullStory from '@fullstory/browser';
+// import FullStory from '@fullstory/react-native';
 import SentryFullStory from '@sentry/fullstory';
 
 FullStory.init({ orgId: '__FULLSTORY_ORG_ID__' });
 
 Sentry.init({
   dsn: '__DSN__',
-  integrations: [ new SentryFullStory('__SENTRY_ORG_SLUG__'), ],
+  integrations: [
+    new SentryFullStory('__SENTRY_ORG_SLUG__', { client: FullStory }),
+  ],
   // ...
 });
-  ```
+```
 
 Replace `__SENTRY_ORG_SLUG__` with the slug of your organization. You can get that value from the URL of your sentry organization. Example: `https://sentry.io/organizations/fullstory/` where `fullstory` would be the value of `__SENTRY_ORG_SLUG__`.
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,9 @@
     "url": "https://github.com/getsentry/sentry-fullstory/issues"
   },
   "homepage": "https://github.com/getsentry/sentry-fullstory#readme",
-  "peerDependencies": {},
+  "peerDependencies": {
+  	"@sentry/core": "4.x || 5.x || 6.x || 7.x"
+  },
   "dependencies": {},
   "devDependencies": {
     "@babel/core": "^7.7.2",

--- a/package.json
+++ b/package.json
@@ -23,15 +23,12 @@
     "url": "https://github.com/getsentry/sentry-fullstory/issues"
   },
   "homepage": "https://github.com/getsentry/sentry-fullstory#readme",
-  "peerDependencies": {
-    "@fullstory/browser": ">=1.0.0",
-    "@sentry/browser": ">=4.0.0"
+  "peerDependencies": {},
+  "dependencies": {
+    "@sentry/core": "^7.16.0"
   },
-  "dependencies": {},
   "devDependencies": {
     "@babel/core": "^7.7.2",
-    "@fullstory/browser": "^1.0.1",
-    "@sentry/browser": "^5.10.2",
     "@sentry/types": "^5.10.0",
     "rimraf": "^3.0.0",
     "rollup": "^1.26.3",

--- a/package.json
+++ b/package.json
@@ -24,12 +24,10 @@
   },
   "homepage": "https://github.com/getsentry/sentry-fullstory#readme",
   "peerDependencies": {},
-  "dependencies": {
-    "@sentry/core": "^7.16.0"
-  },
+  "dependencies": {},
   "devDependencies": {
     "@babel/core": "^7.7.2",
-    "@sentry/types": "^5.10.0",
+    "@sentry/types": "^7.18.0",
     "rimraf": "^3.0.0",
     "rollup": "^1.26.3",
     "rollup-plugin-babel": "^4.3.3",

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,9 @@
-export interface FullStoryClient {
+type WebArgs = (now?: true) => string | null;
+type ReactNativeArgs = () => Promise<string>;
+
+type GetCurrentSessionURLType = WebArgs | ReactNativeArgs;
+
+export type FullStoryClient = {
   event(eventName: string, eventProperties: { [key: string]: any }): void;
-  getCurrentSessionURL(now?: boolean): string | null;
-}
+  getCurrentSessionURL: GetCurrentSessionURLType;
+};

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,5 +1,4 @@
-import { EventHint } from '@sentry/types';
-import { getCurrentHub } from '@sentry/core';
+import type { EventHint, Hub } from '@sentry/types';
 
 /**
  * Returns true if Fullstory is installed correctly.
@@ -38,24 +37,30 @@ export const getOriginalExceptionProperties = (hint?: EventHint) => {
  * Returns the sentry URL of the error. If we cannot get the URL, return a
  * string saying we cannot.
  */
-export function getSentryUrl(args: {
+export function getSentryUrl({
+  hint,
+  sentryOrg,
+  baseSentryUrl,
+  hub,
+}: {
   hint?: EventHint;
   sentryOrg: string;
   baseSentryUrl: string;
+  hub: Hub;
 }) {
   try {
     // No docs on this but the SDK team assures me it works unless you bind another Sentry client
-    const { dsn } = getCurrentHub().getClient()?.getOptions() || {};
+    const { dsn } = hub.getClient()?.getOptions() || {};
     if (!dsn) {
       console.error('No sn');
       return 'Could not retrieve url';
     }
-    if (!args.hint) {
+    if (!hint) {
       console.error('No event hint');
       return 'Could not retrieve url';
     }
     const projectId = getProjectIdFromSentryDsn(dsn);
-    return `${args.baseSentryUrl}/organizations/${args.sentryOrg}/issues/?project=${projectId}&query=${args.hint.event_id}`;
+    return `${baseSentryUrl}/organizations/${sentryOrg}/issues/?project=${projectId}&query=${hint.event_id}`;
   } catch (err) {
     console.error('Error retrieving project ID from DSN', err);
     //TODO: Could put link to a help here

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,5 +1,5 @@
 import { EventHint } from '@sentry/types';
-import * as Sentry from '@sentry/browser';
+import { getCurrentHub } from '@sentry/core';
 
 /**
  * Returns true if Fullstory is installed correctly.
@@ -38,10 +38,14 @@ export const getOriginalExceptionProperties = (hint?: EventHint) => {
  * Returns the sentry URL of the error. If we cannot get the URL, return a
  * string saying we cannot.
  */
-export function getSentryUrl(args: { hint?: EventHint, sentryOrg: string, baseSentryUrl: string }) {
+export function getSentryUrl(args: {
+  hint?: EventHint;
+  sentryOrg: string;
+  baseSentryUrl: string;
+}) {
   try {
     // No docs on this but the SDK team assures me it works unless you bind another Sentry client
-    const { dsn } = Sentry.getCurrentHub().getClient()?.getOptions() || {};
+    const { dsn } = getCurrentHub().getClient()?.getOptions() || {};
     if (!dsn) {
       console.error('No sn');
       return 'Could not retrieve url';

--- a/yarn.lock
+++ b/yarn.lock
@@ -134,61 +134,31 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
-"@fullstory/browser@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@fullstory/browser/-/browser-1.0.1.tgz#a513c13fe5f689f00bbd98bbcdb3d470da58e2e2"
-  integrity sha512-23PhplNWI77AxLYANKOMjDYOylaK4NnmlND498upH1xgYUDoH7E7SZVaXYwVCoeCAS2tFEstkyy4aLDue7EOTg==
-
-"@sentry/browser@^5.10.2":
-  version "5.10.2"
-  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-5.10.2.tgz#0bbb05505c58ea998c833cffec3f922fe4b4fa58"
-  integrity sha512-r3eyBu2ln7odvWtXARCZPzpuGrKsD6U9F3gKTu4xdFkA0swSLUvS7AC2FUksj/1BE23y+eB/zzPT+RYJ58tidA==
+"@sentry/core@^7.16.0":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-7.16.0.tgz#60f9b54ef2ec524176b329e1d15be39c36da5953"
+  integrity sha512-vq6H1b/IPTvzDD9coQ3wIudvSjkAYuUlXb1dv69dRlq4v3st9dcKBps1Zf0lQ1i4TVlDLoe1iGMmNFglMF1Q5w==
   dependencies:
-    "@sentry/core" "5.10.2"
-    "@sentry/types" "5.10.0"
-    "@sentry/utils" "5.10.2"
+    "@sentry/types" "7.16.0"
+    "@sentry/utils" "7.16.0"
     tslib "^1.9.3"
 
-"@sentry/core@5.10.2":
-  version "5.10.2"
-  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-5.10.2.tgz#1cb64489e6f8363c3249415b49d3f1289814825f"
-  integrity sha512-sKVeFH3v8K8xw2vM5MKMnnyAAwih+JSE3pbNL0CcCCA+/SwX+3jeAo2BhgXev2SAR/TjWW+wmeC9TdIW7KyYbg==
-  dependencies:
-    "@sentry/hub" "5.10.2"
-    "@sentry/minimal" "5.10.2"
-    "@sentry/types" "5.10.0"
-    "@sentry/utils" "5.10.2"
-    tslib "^1.9.3"
+"@sentry/types@7.16.0":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-7.16.0.tgz#79c06ada153a84feb949fa49b1c9d15f91decd79"
+  integrity sha512-i6D+OK6d0l/k+VQvRp/Pt21WkDEgVBUIZq+sOkEZJczbcfexVdXKeXXoYTD2vYuFq8Yy28fzlsZaKI+NoH94yQ==
 
-"@sentry/hub@5.10.2":
-  version "5.10.2"
-  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-5.10.2.tgz#25d9f36b8f7c5cb65cf486737fa61dc9bf69b7e3"
-  integrity sha512-hSlZIiu3hcR/I5yEhlpN9C0nip+U7hiRzRzUQaBiHO4YG4TC58NqnOPR89D/ekiuHIXzFpjW9OQmqtAMRoSUYA==
-  dependencies:
-    "@sentry/types" "5.10.0"
-    "@sentry/utils" "5.10.2"
-    tslib "^1.9.3"
-
-"@sentry/minimal@5.10.2":
-  version "5.10.2"
-  resolved "https://registry.yarnpkg.com/@sentry/minimal/-/minimal-5.10.2.tgz#267c2f3aa6877a0fe7a86971942e83f3ee616580"
-  integrity sha512-GalixiM9sckYfompH5HHTp9XT2BcjawBkcl1DMEKUBEi37+kUq0bivOBmnN1G/I4/wWOUdnAI/kagDWaWpbZPg==
-  dependencies:
-    "@sentry/hub" "5.10.2"
-    "@sentry/types" "5.10.0"
-    tslib "^1.9.3"
-
-"@sentry/types@5.10.0", "@sentry/types@^5.10.0":
+"@sentry/types@^5.10.0":
   version "5.10.0"
   resolved "https://registry.yarnpkg.com/@sentry/types/-/types-5.10.0.tgz#4f0ba31b6e4d5371112c38279f11f66c73b43746"
   integrity sha512-TW20GzkCWsP6uAxR2JIpIkiitCKyIOfkyDsKBeLqYj4SaZjfvBPnzgNCcYR0L0UsP1/Es6oHooZfIGSkp6GGxQ==
 
-"@sentry/utils@5.10.2":
-  version "5.10.2"
-  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-5.10.2.tgz#261f575079d30aaf604e59f5f4de0aa21db22252"
-  integrity sha512-UcbbaFpYrGSV448lQ16Cr+W/MPuKUflQQUdrMCt5vgaf5+M7kpozlcji4GGGZUCXIA7oRP93ABoXj55s1OM9zw==
+"@sentry/utils@7.16.0":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-7.16.0.tgz#b832520c661d4435808969ee04814ff8e20497b1"
+  integrity sha512-3Zh1txg7IRp4kZAdG27YF7K6lD1IZyuAo9KjoPg1Xzqa4DOZyASJuEkbf+rK2a9T4HrtVHHXJUsNbKg8WM3VHg==
   dependencies:
-    "@sentry/types" "5.10.0"
+    "@sentry/types" "7.16.0"
     tslib "^1.9.3"
 
 "@types/estree@*":
@@ -553,10 +523,15 @@ to-fast-properties@^2.0.0:
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-2.0.0.tgz#dc5e698cbd079265bc73e0377681a4e4e83f616e"
   integrity sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=
 
-tslib@1.10.0, tslib@^1.9.3:
+tslib@1.10.0:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
   integrity sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==
+
+tslib@^1.9.3:
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
+  integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
 typescript@^3.8:
   version "3.9.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -134,32 +134,10 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
-"@sentry/core@^7.16.0":
-  version "7.16.0"
-  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-7.16.0.tgz#60f9b54ef2ec524176b329e1d15be39c36da5953"
-  integrity sha512-vq6H1b/IPTvzDD9coQ3wIudvSjkAYuUlXb1dv69dRlq4v3st9dcKBps1Zf0lQ1i4TVlDLoe1iGMmNFglMF1Q5w==
-  dependencies:
-    "@sentry/types" "7.16.0"
-    "@sentry/utils" "7.16.0"
-    tslib "^1.9.3"
-
-"@sentry/types@7.16.0":
-  version "7.16.0"
-  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-7.16.0.tgz#79c06ada153a84feb949fa49b1c9d15f91decd79"
-  integrity sha512-i6D+OK6d0l/k+VQvRp/Pt21WkDEgVBUIZq+sOkEZJczbcfexVdXKeXXoYTD2vYuFq8Yy28fzlsZaKI+NoH94yQ==
-
-"@sentry/types@^5.10.0":
-  version "5.10.0"
-  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-5.10.0.tgz#4f0ba31b6e4d5371112c38279f11f66c73b43746"
-  integrity sha512-TW20GzkCWsP6uAxR2JIpIkiitCKyIOfkyDsKBeLqYj4SaZjfvBPnzgNCcYR0L0UsP1/Es6oHooZfIGSkp6GGxQ==
-
-"@sentry/utils@7.16.0":
-  version "7.16.0"
-  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-7.16.0.tgz#b832520c661d4435808969ee04814ff8e20497b1"
-  integrity sha512-3Zh1txg7IRp4kZAdG27YF7K6lD1IZyuAo9KjoPg1Xzqa4DOZyASJuEkbf+rK2a9T4HrtVHHXJUsNbKg8WM3VHg==
-  dependencies:
-    "@sentry/types" "7.16.0"
-    tslib "^1.9.3"
+"@sentry/types@^7.18.0":
+  version "7.18.0"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-7.18.0.tgz#8b0eacd19cc9bcd1f14ca5dcaf7065ebd3186632"
+  integrity sha512-bOnyoK1S1chPJ+dAeWJo0srxZ9U48WE5dZFtvKeXoog6JNHY3nqAR/P/uxh9djB4bbwQRMdnGk1zm0bxhOOC6w==
 
 "@types/estree@*":
   version "0.0.39"
@@ -527,11 +505,6 @@ tslib@1.10.0:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
   integrity sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==
-
-tslib@^1.9.3:
-  version "1.14.1"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
-  integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
 typescript@^3.8:
   version "3.9.7"


### PR DESCRIPTION
Fixes: https://github.com/getsentry/sentry-react-native/issues/1966

- Removed the browser dependencies (both sentry and fullstory)
- Added only the `@sentry/core` dependency
- Made the client option required, so either the React Native or Web FullStory client can be passed from the user-land

**BREAKING:** The client option is now required.

If this implementation is reviewed and accepted, I'll update the README to reflect on the latest breaking changes and produce a simple Migration documentation.