### PR TITLE
feat: add support for @fullstory/browser v2

### DIFF
--- a/src/SentryFullStory.ts
+++ b/src/SentryFullStory.ts
@@ -35,7 +35,7 @@ class SentryFullStory implements Integration {
     // If an error occurs before getCurrentSessionURL is ready, make a note in Sentry and move on.
     // More on getCurrentSessionURL here: https://help.fullstory.com/develop-js/getcurrentsessionurl
     try {
-      const res = this.client.getCurrentSessionURL(true);
+      const res = this.client.getCurrentSessionURL?.(true);
       if (!res) {
         throw new Error('No FullStory session URL found');
       }

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,5 +5,5 @@ type GetCurrentSessionURLType = WebArgs | ReactNativeArgs;
 
 export type FullStoryClient = {
   event(eventName: string, eventProperties: { [key: string]: any }): void;
-  getCurrentSessionURL: GetCurrentSessionURLType;
+  getCurrentSessionURL?: GetCurrentSessionURLType;
 };


### PR DESCRIPTION
The corresponding types in `@fullstory/snippet` were updated such that `getCurrentSessionURL` is optional. I suspect it's because this function is deprecated in `@fullstory/browser` v2, but not sure 🤷 

In any case, this PR updates the corresponding `FullStoryClient` type to reflect this as well as the `getFullStoryUrl` function. I tested these changes in my app with `@fullstory/browser@2.0.0` and confirmed the `fullStoryUrl` still shows up in Sentry.

Fixes #85