### PR TITLE
feat: add support for sentry v8

### DIFF
--- a/.github/workflows/deploy-prep.yml
+++ b/.github/workflows/deploy-prep.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Cache node modules
         uses: actions/setup-node@v2
         with:
-          node-version: '12'
+          node-version: '18'
           cache: 'yarn'
 
       - name: Install node modules

--- a/package.json
+++ b/package.json
@@ -24,12 +24,13 @@
   },
   "homepage": "https://github.com/getsentry/sentry-fullstory#readme",
   "peerDependencies": {
-    "@sentry/core": "4.x || 5.x || 6.x || 7.x"
+    "@sentry/core": "4.x || 5.x || 6.x || 7.x || 8.x"
   },
   "dependencies": {},
   "devDependencies": {
     "@babel/core": "^7.7.2",
     "@sentry/types": "^7.18.0",
+    "@sentry/typesv8": "npm:@sentry/types@8.4.0",
     "rimraf": "^3.0.0",
     "rollup": "^1.26.3",
     "rollup-plugin-babel": "^4.3.3",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,5 @@
   "volta": {
     "node": "12.19.0",
     "yarn": "1.22.5"
-  },
-  "packageManager": "yarn@1.22.19+sha1.4ba7fc5c6e704fce2066ecbfb0b0d8976fe62447"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -24,13 +24,12 @@
   },
   "homepage": "https://github.com/getsentry/sentry-fullstory#readme",
   "peerDependencies": {
-    "@sentry/core": "4.x || 5.x || 6.x || 7.x || 8.x"
+    "@sentry/core": "8.x"
   },
   "dependencies": {},
   "devDependencies": {
     "@babel/core": "^7.7.2",
-    "@sentry/types": "^7.18.0",
-    "@sentry/typesv8": "npm:@sentry/types@8.4.0",
+    "@sentry/types": "^8.4.0",
     "rimraf": "^3.0.0",
     "rollup": "^1.26.3",
     "rollup-plugin-babel": "^4.3.3",
@@ -40,5 +39,6 @@
   "volta": {
     "node": "12.19.0",
     "yarn": "1.22.5"
-  }
+  },
+  "packageManager": "yarn@1.22.19+sha1.4ba7fc5c6e704fce2066ecbfb0b0d8976fe62447"
 }

--- a/src/SentryFullStory.ts
+++ b/src/SentryFullStory.ts
@@ -1,7 +1,21 @@
-import type { EventProcessor, Hub, Integration } from '@sentry/types';
+import type {
+  Client,
+  Event,
+  EventHint,
+  EventProcessor,
+  Hub,
+  Integration,
+} from '@sentry/types';
+import type {
+  Client as ClientV8,
+  Event as EventV8,
+  EventHint as EventHintV8,
+  Integration as IntegrationV8,
+} from '@sentry/typesv8';
 import type { FullStoryClient } from './types';
 import {
   doesFullStoryExist,
+  getFullStoryUrl,
   getOriginalExceptionProperties,
   getSentryUrl,
 } from './util';
@@ -17,9 +31,81 @@ type Options = {
   baseSentryUrl?: string;
 };
 
+const INTEGRATION_NAME = 'SentryFullStory';
+
+type ProcessEventOptions = {
+  baseSentryUrl: string;
+  client: FullStoryClient;
+  event: Event;
+  hint: EventHint;
+  self: Integration | null;
+  sentryClient?: Client;
+  sentryOrg: string;
+  fullStoryUrl?: string;
+};
+
+type ProcessEventOptionsV8 = {
+  baseSentryUrl: string;
+  client: FullStoryClient;
+  event: EventV8;
+  hint: EventHintV8;
+  self: IntegrationV8 | undefined;
+  sentryClient?: ClientV8;
+  sentryOrg: string;
+  fullStoryUrl?: string;
+};
+
+async function processEvent({
+  baseSentryUrl,
+  client,
+  event,
+  hint,
+  self,
+  sentryOrg,
+  sentryClient,
+  fullStoryUrl,
+}: ProcessEventOptions | ProcessEventOptionsV8): Promise<Event | EventV8> {
+  // Run the integration ONLY when it was installed on the current Hub AND isn't a transaction
+  if (self && event.type !== 'transaction' && doesFullStoryExist()) {
+    if (!fullStoryUrl) {
+      try {
+        fullStoryUrl = await getFullStoryUrl(client);
+      } catch (e) {
+        const reason = e instanceof Error ? e.message : String(e);
+        console.error(`Unable to get FullStory session URL: ${reason}`);
+      }
+    }
+  }
+
+  if (fullStoryUrl) {
+    event.contexts = {
+      ...event.contexts,
+      fullStory: {
+        fullStoryUrl,
+      },
+    };
+  }
+
+  try {
+    client.event('Sentry Error', {
+      sentryUrl: getSentryUrl({
+        baseSentryUrl: baseSentryUrl,
+        sentryOrg,
+        hint,
+        client: sentryClient,
+      }),
+      ...getOriginalExceptionProperties(hint),
+    });
+  } catch (e) {
+    console.debug('Unable to report sentry error details to FullStory');
+  }
+
+  return event;
+}
+
 class SentryFullStory implements Integration {
   public readonly name: string = SentryFullStory.id;
-  public static id: string = 'SentryFullStory';
+  public static id = INTEGRATION_NAME;
   sentryOrg: string;
   baseSentryUrl: string;
   client: FullStoryClient;
@@ -30,23 +116,6 @@ class SentryFullStory implements Integration {
     this.baseSentryUrl = options.baseSentryUrl || 'https://sentry.io';
   }
 
-  getFullStoryUrl = (): Promise<string> | string => {
-    // getCurrentSessionURL isn't available until after the FullStory script is fully bootstrapped.
-    // If an error occurs before getCurrentSessionURL is ready, make a note in Sentry and move on.
-    // More on getCurrentSessionURL here: https://help.fullstory.com/develop-js/getcurrentsessionurl
-    try {
-      const res = this.client.getCurrentSessionURL?.(true);
-      if (!res) {
-        throw new Error('No FullStory session URL found');
-      }
-
-      return res;
-    } catch (e) {
-      const reason = e instanceof Error ? e.message : String(e);
-      throw new Error(`Unable to get url: ${reason}`);
-    }
-  };
-
   setupOnce(
     addGlobalEventProcessor: (callback: EventProcessor) => void,
     getCurrentHub: () => Hub
@@ -55,45 +124,43 @@ class SentryFullStory implements Integration {
 
     addGlobalEventProcessor(async (event, hint) => {
       const hub = getCurrentHub();
-      const self = hub.getIntegration(SentryFullStory);
-      // Run the integration ONLY when it was installed on the current Hub AND isn't a transaction
-      if (self && event.type !== 'transaction' && doesFullStoryExist()) {
-        if (!fullStoryUrl) {
-          try {
-            fullStoryUrl = await this.getFullStoryUrl();
-          } catch (e) {
-            const reason = e instanceof Error ? e.message : String(e);
-            console.error(`Unable to get FullStory session URL: ${reason}`);
-          }
-        }
-
-        if (fullStoryUrl) {
-          event.contexts = {
-            ...event.contexts,
-            fullStory: {
-              fullStoryUrl,
-            },
-          };
-        }
-
-        try {
-          this.client.event('Sentry Error', {
-            sentryUrl: getSentryUrl({
-              baseSentryUrl: this.baseSentryUrl,
-              sentryOrg: this.sentryOrg,
-              hint,
-              hub,
-            }),
-            ...getOriginalExceptionProperties(hint),
-          });
-        } catch (e) {
-          console.debug('Unable to report sentry error details to FullStory');
-        }
-      }
-
-      return event;
+      return processEvent({
+        baseSentryUrl: this.baseSentryUrl,
+        client: this.client,
+        event,
+        hint,
+        self: hub.getIntegration(SentryFullStory),
+        sentryClient: hub.getClient(),
+        sentryOrg: this.sentryOrg,
+        fullStoryUrl,
+      }) as Promise<Event>;
     });
   }
+}
+
+export function fullStoryIntegration(
+  sentryOrg: string,
+  options: Options
+): IntegrationV8 {
+  const fullStoryClient = options.client;
+  const baseSentryUrl = options.baseSentryUrl || 'https://sentry.io';
+  let fullStoryUrl: string | undefined;
+
+  return {
+    name: INTEGRATION_NAME,
+    async processEvent(event, hint, client) {
+      return processEvent({
+        baseSentryUrl: baseSentryUrl,
+        client: fullStoryClient,
+        event,
+        hint,
+        self: client.getIntegrationByName(INTEGRATION_NAME),
+        sentryClient: client,
+        sentryOrg,
+        fullStoryUrl,
+      }) as Promise<EventV8>;
+    },
+  };
 }
 
 export default SentryFullStory;

--- a/src/SentryFullStory.ts
+++ b/src/SentryFullStory.ts
@@ -1,17 +1,4 @@
-import type {
-  Client,
-  Event,
-  EventHint,
-  EventProcessor,
-  Hub,
-  Integration,
-} from '@sentry/types';
-import type {
-  Client as ClientV8,
-  Event as EventV8,
-  EventHint as EventHintV8,
-  Integration as IntegrationV8,
-} from '@sentry/typesv8';
+import type { Integration } from '@sentry/types';
 import type { FullStoryClient } from './types';
 import {
   doesFullStoryExist,
@@ -33,115 +20,10 @@ type Options = {
 
 const INTEGRATION_NAME = 'SentryFullStory';
 
-type ProcessEventOptions = {
-  baseSentryUrl: string;
-  client: FullStoryClient;
-  event: Event;
-  hint: EventHint;
-  self: Integration | null;
-  sentryClient?: Client;
-  sentryOrg: string;
-  fullStoryUrl?: string;
-};
-
-type ProcessEventOptionsV8 = {
-  baseSentryUrl: string;
-  client: FullStoryClient;
-  event: EventV8;
-  hint: EventHintV8;
-  self: IntegrationV8 | undefined;
-  sentryClient?: ClientV8;
-  sentryOrg: string;
-  fullStoryUrl?: string;
-};
-
-async function processEvent({
-  baseSentryUrl,
-  client,
-  event,
-  hint,
-  self,
-  sentryOrg,
-  sentryClient,
-  fullStoryUrl,
-}: ProcessEventOptions | ProcessEventOptionsV8): Promise<Event | EventV8> {
-  // Run the integration ONLY when it was installed on the current Hub AND isn't a transaction
-  if (self && event.type !== 'transaction' && doesFullStoryExist()) {
-    if (!fullStoryUrl) {
-      try {
-        fullStoryUrl = await getFullStoryUrl(client);
-      } catch (e) {
-        const reason = e instanceof Error ? e.message : String(e);
-        console.error(`Unable to get FullStory session URL: ${reason}`);
-      }
-    }
-  }
-
-  if (fullStoryUrl) {
-    event.contexts = {
-      ...event.contexts,
-      fullStory: {
-        fullStoryUrl,
-      },
-    };
-  }
-
-  try {
-    client.event('Sentry Error', {
-      sentryUrl: getSentryUrl({
-        baseSentryUrl: baseSentryUrl,
-        sentryOrg,
-        hint,
-        client: sentryClient,
-      }),
-      ...getOriginalExceptionProperties(hint),
-    });
-  } catch (e) {
-    console.debug('Unable to report sentry error details to FullStory');
-  }
-
-  return event;
-}
-
-class SentryFullStory implements Integration {
-  public readonly name: string = SentryFullStory.id;
-  public static id = INTEGRATION_NAME;
-  sentryOrg: string;
-  baseSentryUrl: string;
-  client: FullStoryClient;
-
-  constructor(sentryOrg: string, options: Options) {
-    this.sentryOrg = sentryOrg;
-    this.client = options.client;
-    this.baseSentryUrl = options.baseSentryUrl || 'https://sentry.io';
-  }
-
-  setupOnce(
-    addGlobalEventProcessor: (callback: EventProcessor) => void,
-    getCurrentHub: () => Hub
-  ) {
-    let fullStoryUrl: string | undefined;
-
-    addGlobalEventProcessor(async (event, hint) => {
-      const hub = getCurrentHub();
-      return processEvent({
-        baseSentryUrl: this.baseSentryUrl,
-        client: this.client,
-        event,
-        hint,
-        self: hub.getIntegration(SentryFullStory),
-        sentryClient: hub.getClient(),
-        sentryOrg: this.sentryOrg,
-        fullStoryUrl,
-      }) as Promise<Event>;
-    });
-  }
-}
-
 export function fullStoryIntegration(
   sentryOrg: string,
   options: Options
-): IntegrationV8 {
+): Integration {
   const fullStoryClient = options.client;
   const baseSentryUrl = options.baseSentryUrl || 'https://sentry.io';
   let fullStoryUrl: string | undefined;
@@ -149,18 +31,43 @@ export function fullStoryIntegration(
   return {
     name: INTEGRATION_NAME,
     async processEvent(event, hint, client) {
-      return processEvent({
-        baseSentryUrl: baseSentryUrl,
-        client: fullStoryClient,
-        event,
-        hint,
-        self: client.getIntegrationByName(INTEGRATION_NAME),
-        sentryClient: client,
-        sentryOrg,
-        fullStoryUrl,
-      }) as Promise<EventV8>;
+      const self = client.getIntegrationByName(INTEGRATION_NAME);
+      // Run the integration ONLY when it was installed on the current Hub AND isn't a transaction
+      if (self && event.type === undefined && doesFullStoryExist()) {
+        if (!fullStoryUrl) {
+          try {
+            fullStoryUrl = await getFullStoryUrl(fullStoryClient);
+          } catch (e) {
+            const reason = e instanceof Error ? e.message : String(e);
+            console.error(`Unable to get FullStory session URL: ${reason}`);
+          }
+        }
+      }
+
+      if (fullStoryUrl) {
+        event.contexts = {
+          ...event.contexts,
+          fullStory: {
+            fullStoryUrl,
+          },
+        };
+      }
+
+      try {
+        fullStoryClient.event('Sentry Error', {
+          sentryUrl: getSentryUrl({
+            baseSentryUrl: baseSentryUrl,
+            sentryOrg,
+            hint,
+            client,
+          }),
+          ...getOriginalExceptionProperties(hint),
+        });
+      } catch (e) {
+        console.debug('Unable to report sentry error details to FullStory');
+      }
+
+      return event;
     },
   };
 }
-
-export default SentryFullStory;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,1 @@
-export { default, fullStoryIntegration } from './SentryFullStory';
+export { fullStoryIntegration } from './SentryFullStory';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,1 @@
-import SentryFullStory from './SentryFullStory';
-
-export default SentryFullStory;
+export { default, fullStoryIntegration } from './SentryFullStory';

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,9 +1,5 @@
-import type { EventHint, Client } from '@sentry/types';
-import type {
-  Client as ClientV8,
-  EventHint as EventHintV8,
-} from '@sentry/typesv8';
-import type { FullStoryClient } from './types';
+import type { Client, EventHint } from '@sentry/types';
+import { FullStoryClient } from './types';
 
 /**
  * Returns true if Fullstory is installed correctly.
@@ -28,9 +24,7 @@ const isError = (exception: unknown): exception is Error => {
  * Get the message and name properties from the original exception
  * @param {EventHint} hint
  */
-export const getOriginalExceptionProperties = (
-  hint?: EventHint | EventHintV8
-) => {
+export const getOriginalExceptionProperties = (hint?: EventHint) => {
   if (hint && hint.originalException && isError(hint.originalException)) {
     const originalException = hint.originalException;
     const { name, message } = originalException;
@@ -50,14 +44,14 @@ export function getSentryUrl({
   baseSentryUrl,
   client,
 }: {
-  hint?: EventHint | EventHintV8;
+  hint?: EventHint;
   sentryOrg: string;
   baseSentryUrl: string;
-  client?: Client | ClientV8;
+  client: Client;
 }) {
   try {
     // No docs on this but the SDK team assures me it works unless you bind another Sentry client
-    const { dsn } = client?.getOptions() || {};
+    const { dsn } = client.getOptions();
     if (!dsn) {
       console.error('No sn');
       return 'Could not retrieve url';

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,4 +1,9 @@
-import type { EventHint, Hub } from '@sentry/types';
+import type { EventHint, Client } from '@sentry/types';
+import type {
+  Client as ClientV8,
+  EventHint as EventHintV8,
+} from '@sentry/typesv8';
+import type { FullStoryClient } from './types';
 
 /**
  * Returns true if Fullstory is installed correctly.
@@ -15,7 +20,7 @@ export const getProjectIdFromSentryDsn = (dsn: string) => {
   return new URL(dsn).pathname.replace('/', '');
 };
 
-const isError = (exception: string | Error): exception is Error => {
+const isError = (exception: unknown): exception is Error => {
   return (exception as Error).message !== undefined;
 };
 
@@ -23,7 +28,9 @@ const isError = (exception: string | Error): exception is Error => {
  * Get the message and name properties from the original exception
  * @param {EventHint} hint
  */
-export const getOriginalExceptionProperties = (hint?: EventHint) => {
+export const getOriginalExceptionProperties = (
+  hint?: EventHint | EventHintV8
+) => {
   if (hint && hint.originalException && isError(hint.originalException)) {
     const originalException = hint.originalException;
     const { name, message } = originalException;
@@ -41,16 +48,16 @@ export function getSentryUrl({
   hint,
   sentryOrg,
   baseSentryUrl,
-  hub,
+  client,
 }: {
-  hint?: EventHint;
+  hint?: EventHint | EventHintV8;
   sentryOrg: string;
   baseSentryUrl: string;
-  hub: Hub;
+  client?: Client | ClientV8;
 }) {
   try {
     // No docs on this but the SDK team assures me it works unless you bind another Sentry client
-    const { dsn } = hub.getClient()?.getOptions() || {};
+    const { dsn } = client?.getOptions() || {};
     if (!dsn) {
       console.error('No sn');
       return 'Could not retrieve url';
@@ -65,5 +72,24 @@ export function getSentryUrl({
     console.error('Error retrieving project ID from DSN', err);
     //TODO: Could put link to a help here
     return 'Could not retrieve url';
+  }
+}
+
+export function getFullStoryUrl(
+  fullStoryClient: FullStoryClient
+): Promise<string> | string {
+  // getCurrentSessionURL isn't available until after the FullStory script is fully bootstrapped.
+  // If an error occurs before getCurrentSessionURL is ready, make a note in Sentry and move on.
+  // More on getCurrentSessionURL here: https://help.fullstory.com/develop-js/getcurrentsessionurl
+  try {
+    const res = fullStoryClient.getCurrentSessionURL?.(true);
+    if (!res) {
+      throw new Error('No FullStory session URL found');
+    }
+
+    return res;
+  } catch (e) {
+    const reason = e instanceof Error ? e.message : String(e);
+    throw new Error(`Unable to get url: ${reason}`);
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -134,12 +134,7 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
-"@sentry/types@^7.18.0":
-  version "7.18.0"
-  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-7.18.0.tgz#8b0eacd19cc9bcd1f14ca5dcaf7065ebd3186632"
-  integrity sha512-bOnyoK1S1chPJ+dAeWJo0srxZ9U48WE5dZFtvKeXoog6JNHY3nqAR/P/uxh9djB4bbwQRMdnGk1zm0bxhOOC6w==
-
-"@sentry/typesv8@npm:@sentry/types@8.4.0":
+"@sentry/types@^8.4.0":
   version "8.4.0"
   resolved "https://registry.yarnpkg.com/@sentry/types/-/types-8.4.0.tgz#42500005a198ff8c247490434ed55e0a9f975ad1"
   integrity sha512-mHUaaYEQCNukzYsTLp4rP2NNO17vUf+oSGS6qmhrsGqmGNICKw2CIwJlPPGeAkq9Y4tiUOye2m5OT1xsOtxLIw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -139,6 +139,11 @@
   resolved "https://registry.yarnpkg.com/@sentry/types/-/types-7.18.0.tgz#8b0eacd19cc9bcd1f14ca5dcaf7065ebd3186632"
   integrity sha512-bOnyoK1S1chPJ+dAeWJo0srxZ9U48WE5dZFtvKeXoog6JNHY3nqAR/P/uxh9djB4bbwQRMdnGk1zm0bxhOOC6w==
 
+"@sentry/typesv8@npm:@sentry/types@8.4.0":
+  version "8.4.0"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-8.4.0.tgz#42500005a198ff8c247490434ed55e0a9f975ad1"
+  integrity sha512-mHUaaYEQCNukzYsTLp4rP2NNO17vUf+oSGS6qmhrsGqmGNICKw2CIwJlPPGeAkq9Y4tiUOye2m5OT1xsOtxLIw==
+
 "@types/estree@*":
   version "0.0.39"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"


### PR DESCRIPTION
Closes #91 

Hey @AbhiPrasad @scefali 👋 

This PR is a breaking change that updates `@sentry/fullstory` to be compatible with Sentry 8.x. With these changes, the usage now looks like:

```js
import { fullStoryIntegration } from '@sentry/fullstory';

// ...

Sentry.init({
  dsn: '__DSN__',
  integrations: [
    fullStoryIntegration('__SENTRY_ORG_SLUG__', { client: FullStory }),
  ],
  // ...
});
```