### PR TITLE
fix: don't send FS events for non-errors

### DIFF
--- a/src/integration.ts
+++ b/src/integration.ts
@@ -42,29 +42,29 @@ export function fullStoryIntegration(
             console.error(`Unable to get FullStory session URL: ${reason}`);
           }
         }
-      }
 
-      if (fullStoryUrl) {
-        event.contexts = {
-          ...event.contexts,
-          fullStory: {
-            fullStoryUrl,
-          },
-        };
-      }
+        if (fullStoryUrl) {
+          event.contexts = {
+            ...event.contexts,
+            fullStory: {
+              fullStoryUrl,
+            },
+          };
+        }
 
-      try {
-        fullStoryClient.event('Sentry Error', {
-          sentryUrl: getSentryUrl({
-            baseSentryUrl: baseSentryUrl,
-            sentryOrg,
-            hint,
-            client,
-          }),
-          ...getOriginalExceptionProperties(hint),
-        });
-      } catch (e) {
-        console.debug('Unable to report sentry error details to FullStory');
+        try {
+          fullStoryClient.event('Sentry Error', {
+            sentryUrl: getSentryUrl({
+              baseSentryUrl: baseSentryUrl,
+              sentryOrg,
+              hint,
+              client,
+            }),
+            ...getOriginalExceptionProperties(hint),
+          });
+        } catch (e) {
+          console.debug('Unable to report sentry error details to FullStory');
+        }
       }
 
       return event;


### PR DESCRIPTION
Fixes #95 

The integration was already checking whether the `event` being processed is an error (indicated by `event.type === undefined`), but this check was only covering the part where the `fullStoryUrl` is retrieved. It should be covering the rest of the integration logic as well.

cc @AbhiPrasad 