### PR TITLE
feat!: upgrade to Sentry SDK v9

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,11 +32,11 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@sentry/core": "8.x"
+    "@sentry/core": "9.x"
   },
   "dependencies": {},
   "devDependencies": {
-    "@sentry/types": "^8.7.0",
+    "@sentry/core": "^9.7.0",
     "bunchee": "^5.1.5",
     "typescript": "^5.4.5"
   },

--- a/src/integration.ts
+++ b/src/integration.ts
@@ -1,4 +1,4 @@
-import type { Integration } from '@sentry/types';
+import type { Integration } from '@sentry/core';
 import type { FullStoryClient } from './types';
 import {
   doesFullStoryExist,

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,4 +1,4 @@
-import type { Client, EventHint } from '@sentry/types';
+import type { Client, EventHint } from '@sentry/core';
 import { FullStoryClient } from './types';
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -170,10 +170,10 @@
   resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.18.0.tgz#5d694d345ce36b6ecf657349e03eb87297e68da4"
   integrity sha512-UOo5FdvOL0+eIVTgS4tIdbW+TtnBLWg1YBCcU2KWM7nuNwRz9bksDX1bekJJCpu25N1DVWaCwnT39dVQxzqS8g==
 
-"@sentry/types@^8.7.0":
-  version "8.7.0"
-  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-8.7.0.tgz#92731af32318d6abb8759216cf6c3c5035894e6e"
-  integrity sha512-11KLOKumP6akugVGLvSoEig+JlP0ZEzW3nN9P+ppgdIx9HAxMIh6UvumbieG4/DWjAh2kh6NPNfUw3gk2Gfq1A==
+"@sentry/core@^9.7.0":
+  version "9.7.0"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-9.7.0.tgz#897dc7742014db8e35e99f14346a1053af739b75"
+  integrity sha512-EprjtU7F6eltB4Nx8fzWFXsfAC/6yNGuKo2bHKeIAmNufjD0X4ifz+iB3d0pKuwsn9jQbLrQTIGwKdTO3dstFw==
 
 "@swc/core-darwin-arm64@1.5.7":
   version "1.5.7"


### PR DESCRIPTION
Fixes #99 

As mentioned in https://github.com/getsentry/sentry-fullstory/issues/99#issuecomment-2741408292, this PR prepares for a new major version by bumping the peer dependency to v9 of the Sentry SDK. It also swaps out the `@sentry/types` dev dependency with `@sentry/core` since the [types package is now deprecated](https://docs.sentry.io/platforms/javascript/migration/v8-to-v9/#package-removals).